### PR TITLE
Arreglar el detalle de serie para que no se rompa

### DIFF
--- a/_includes/templates/serie-detalle.html
+++ b/_includes/templates/serie-detalle.html
@@ -29,11 +29,13 @@
         </div>
       </div>
       <hr>
-      <div class="row">
       {% assign sorted_pages = site.posts | sort:"name" %}
+      <div class="row">
+      {% assign counter = -1 %}
       {% for post in sorted_pages %}
         {% if post.categories contains page.post_cat %}
-          {% assign num_post = forloop.index0 | modulo:4 %}
+          {% assign counter = counter | plus:1 %}
+          {% assign num_post = counter | modulo:4 %}
           {% if num_post == 0 %}
             </div>
             <div class="row">


### PR DESCRIPTION
Ahora el detalle de serie no se rompe y está ordenado por el nombre del
post, es decir por fecha. este pull-request fixes #43. :gun: :fu:
