### PR TITLE
Eliminar middle ads de las noticias

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -85,7 +85,9 @@ layout: default
         {{ paragraph }}
         {% assign forlength = forloop.length | divided_by:2 %}
         {% if forloop.index == forlength %}
-          {% include middle-post-ad.html %}
+          {% unless page.categories contains 'notícias' %}
+            {% include middle-post-ad.html %}
+          {% endunless %}
         {% endif %}
       {% endfor %}
       <div class="row">


### PR DESCRIPTION
Debido a que las noticias son muy cortas, con el ad del medio se ven muy cargadas de publicidad.

Ahora si un post es una notícia no se le pondrá publicidad en la mitad
