### PR TITLE
Eliminar correo del autor del feed

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -31,7 +31,6 @@ layout: nil
     </content>
     <author>
       <name>{{ post.author }}</name>
-      <email>{{ post.author_email }}</email>
     </author>
   </entry>
   {% endfor %}


### PR DESCRIPTION
Esta propiedad ya no se está colocando en los posts por lo que romperá ese tag del feed. Adicionalmente no es relevante esto en el feed
