### PR TITLE
Agregar soporte para comunidad y contribuciones

### DIFF
--- a/_data/contribuidores.yml
+++ b/_data/contribuidores.yml
@@ -1,0 +1,11 @@
+- name: Mr. Test
+  github: codeheroblog
+  facebook: codeheroblog
+  twitter: codeheroblog
+  gplus: u/0/114001556421077350451
+  linkedin: codeheroblog
+  web: codehero.co
+  email: heroes@codehero.co
+  description: Mr. Test es el placeholder de nuestra página de contribuidores, cuando tengamos el primero él tendrá que irse =(
+  thumb: c8bda21404dda0cdcef8cfa0c34c03de.png
+  namelink: mrtest

--- a/_includes/article-section.html
+++ b/_includes/article-section.html
@@ -22,7 +22,11 @@
     </h1>
     {% unless page.author_name %}
       <p class="author">
-        Publicado por: <a href="/author/{{ post.author_login }}.html">{{ post.author }}</a>,
+        {% if post.categories contains 'comunidad' %}
+          Publicado por: <a href="/contributor/{{ post.author_login }}.html">{{ post.author }}</a>,
+        {% else %}
+          Publicado por: <a href="/author/{{ post.author_login }}.html">{{ post.author }}</a>,
+        {% endif %}
         El {{ post.date | date_to_string }}, Tiene <a href="{{ post.url }}#disqus_thread" data-disqus-identifier="{{ post.url }}/"><!-- comments --></a>
         comentarios.
       </p>

--- a/_includes/page-footer.html
+++ b/_includes/page-footer.html
@@ -23,6 +23,7 @@
               <li class="horizontal-list-style-shits"><a href="/terminos-y-condiciones.html">Terminos y Condiciones</a></li>
               <li class="horizontal-list-style-shits"><a href="/politica-de-privacidad.html">Politica de Privacidad</a></li>
               <li class="horizontal-list-style-shits"><a href="/authors.html">Escritores</a></li>
+              <li class="horizontal-list-style-shits"><a href="/contributors.html">Contribuidores</a></li>
             </ul>
           </div>
         </div>

--- a/_includes/page-header.html
+++ b/_includes/page-header.html
@@ -14,6 +14,7 @@
         <li><a href="/series/">Series</a></li>
         <li><a href="/category/como-lo-hago.html">Cómo lo hago</a></li>
         <li><a href="/category/articulos/noticias.html">Noticias</a></li>
+        <li><a href="/community.html">Comunidad</a></li>
         <li class="hidden-xs"><a href="/search.html"><i class="fa fa-search"></i></a></li>
         <li class="visible-xs"><a href="/search.html"><i class="fa fa-search"></i> Buscar</a></li>
       </ul>

--- a/_includes/templates/autor-description.html
+++ b/_includes/templates/autor-description.html
@@ -2,7 +2,7 @@
   <img class="gravatar-img" src="http://www.gravatar.com/avatar/{{ autor.thumb }}?s=400" alt="gravatar">
 </div>
 <div class="col-xs-9 col-sm-8 col-md-9">
-  <h1 class="underline-title"><a href="/author/{{ autor.namelink }}.html">{{ autor.name }}</a></h1>
+  <h1 class="underline-title"><a href="/contributor/{{ autor.namelink }}.html">{{ autor.name }}</a></h1>
     {% include templates/autor-redes-sociales.html %}
   <p>{{ autor.description }}</p>
 </div>

--- a/_includes/templates/autor-detalle.html
+++ b/_includes/templates/autor-detalle.html
@@ -7,6 +7,11 @@
             {% include templates/autor-description.html %}
           {% endif %}
         {% endfor %}
+        {% for autor in site.data.contribuidores %}
+          {% if autor.name == page.author_name %}
+            {% include templates/autor-description.html %}
+          {% endif %}
+        {% endfor %}
       </div>
     </ul>
     <h2>Publicaciones</h2>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -123,6 +123,11 @@ layout: default
                 <img class="post-author-thumb" src="http://www.gravatar.com/avatar/{{ autor.thumb }}" alt="gravatar">
               {% endif %}
             {% endfor %}
+            {% for autor in site.data.contribuidores %}
+              {% if autor.name == page.author %}
+                <img class="post-author-thumb" src="http://www.gravatar.com/avatar/{{ autor.thumb }}" alt="gravatar">
+              {% endif %}
+            {% endfor %}
           </div>
           <div class="col-xs-12 col-sm-8 col-md-9">
             <h4>Por {{ page.author }}</h4>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -24,7 +24,11 @@ layout: default
           {% else %}
             <h1>{{ page.title }}</h1>
           {% endif %}
-          <p class="author">Publicado Por: <a href="/author/{{ page.author_login }}.html">{{ page.author }}</a>, El {{ page.date | date_to_string }}</p>
+          {% if post.categories contains 'comunidad' %}
+            <p class="author">Publicado Por: <a href="/contributor/{{ page.author_login }}.html">{{ page.author }}</a>, El {{ page.date | date_to_string }}</p>
+          {% else %}
+            <p class="author">Publicado Por: <a href="/author/{{ page.author_login }}.html">{{ page.author }}</a>, El {{ page.date | date_to_string }}</p>
+          {% endif %}
           {% unless page.dificultad or page.duracion %}
             {% include share-buttons.html %}
           {% endunless %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -123,15 +123,14 @@ layout: default
                 <img class="post-author-thumb" src="http://www.gravatar.com/avatar/{{ autor.thumb }}" alt="gravatar">
               {% endif %}
             {% endfor %}
-            {% for autor in site.data.contribuidores %}
-              {% if autor.name == page.author %}
-                <img class="post-author-thumb" src="http://www.gravatar.com/avatar/{{ autor.thumb }}" alt="gravatar">
-              {% endif %}
-            {% endfor %}
           </div>
           <div class="col-xs-12 col-sm-8 col-md-9">
             <h4>Por {{ page.author }}</h4>
-            <p>Conoce más sobre este autor <a href="/author/{{ page.author_login }}.html">aquí</a></p>
+            {% if post.categories contains 'comunidad' %}
+              <p>Conoce más sobre este autor <a href="/contributor/{{ page.author_login }}.html">aquí</a></p>
+            {% else %}
+              <p>Conoce más sobre este autor <a href="/author/{{ page.author_login }}.html">aquí</a></p>
+            {% endif %}
           </div>
         </div>
       </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -119,6 +119,11 @@ layout: default
                 <img class="post-author-thumb" src="http://www.gravatar.com/avatar/{{ autor.thumb }}" alt="gravatar">
               {% endif %}
             {% endfor %}
+            {% for autor in site.data.contribuidores %}
+              {% if autor.name == page.author %}
+                <img class="post-author-thumb" src="http://www.gravatar.com/avatar/{{ autor.thumb }}" alt="gravatar">
+              {% endif %}
+            {% endfor %}
           </div>
           <div class="col-xs-12 col-sm-8 col-md-9">
             <h4>Por {{ page.author }}</h4>

--- a/comunidad.html
+++ b/comunidad.html
@@ -1,0 +1,16 @@
+---
+layout: default
+title: Comunidad
+permalink: community.html
+description: Página de los aportes de la comunidad, aquí encontraras las entradas que han sido escritas por los contribuidores de Codehero.
+---
+<div class="row">
+  <div class="contenido-fondo-blanco col-xs-12 col-sm-9 col-md-9">
+    {% for post in site.posts %}
+      {% if post.categories contains 'comunidad' %}
+        {% include article-section.html %}
+      {% endif %}
+    {% endfor %}
+  </div>
+  {% include ads-section.html %}
+</div>

--- a/contribuidores.html
+++ b/contribuidores.html
@@ -1,0 +1,16 @@
+---
+layout: default
+title: Contribuidores
+permalink: contributors.html
+description: Ficha personal de todos los contribuidores a Codehero.co
+---
+
+<div class="contenido-fondo-blanco col-xs-12 col-sm-9 col-md-9">
+  <ul class="author-list horizontal-list-oscuras">
+    {% for autor in site.data.contribuidores %}
+      <div class="row">
+        {% include templates/autor-description.html %}
+      </div>
+    {% endfor %}
+  </ul>
+</div>

--- a/contributor/mrtest.html
+++ b/contributor/mrtest.html
@@ -1,0 +1,7 @@
+---
+layout: default
+title: Mr. Test
+author_name: Mr. Test
+description: Información de las entradas escritas por Mr. Test en el blog de Codehero.
+---
+{% include templates/autor-detalle.html %}


### PR DESCRIPTION
Closes #91 and closes #87.

Lo puse de una manera que un post de la comunidad debe necesariamente tener una categoría `comunidad` definida en el arreglo de categorías del post.