### PR TITLE
Agregar Revenuehits nuevamente

### DIFF
--- a/_includes/ads-section.html
+++ b/_includes/ads-section.html
@@ -3,7 +3,7 @@
   <div class="center-in-div">
     <div class="ads-border">
       <!-- Sidebar add -->
-      <script type="text/javascript" src="http://srvpub.com/adServe/banners?tid=29738_42511_3&size=120x600" ></script>
+      <script type="text/javascript" src="http://srvpub.com/adServe/banners?tid=29738_42511_3&size=160x600" ></script>
     </div>
 </div>
 </div>

--- a/_includes/ads-section.html
+++ b/_includes/ads-section.html
@@ -3,13 +3,7 @@
   <div class="center-in-div">
     <div class="ads-border">
       <!-- Sidebar add -->
-      <ins class="adsbygoogle"
-         style="display:block"
-         data-ad-client="ca-pub-1352515212336214"
-         data-ad-slot="4722539190"
-         data-ad-format="auto">
-      </ins>
+      <script type="text/javascript" src="http://srvpub.com/adServe/banners?tid=29738_42511_3&size=120x600" ></script>
     </div>
-  <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
 </div>
 </div>

--- a/_includes/bottom-post-ad.html
+++ b/_includes/bottom-post-ad.html
@@ -1,0 +1,8 @@
+<div class="row">
+  <div class="col-xs-12 col-sm-12 col-md-12">
+    <div class="center-in-div">
+      <!-- Bottom ad -->
+      <script type="text/javascript" src="http://srvpub.com/adServe/banners?tid=29738_42511_4&size=300x250" ></script>
+    </div>
+  </div>
+</div>

--- a/_includes/leaderboard-ad.html
+++ b/_includes/leaderboard-ad.html
@@ -2,13 +2,7 @@
   <div class="ads-border col-xs-12 col-sm-9 col-md-9">
     <div class="center-in-div">
       <!-- Top ad -->
-      <ins class="adsbygoogle"
-           style="display:block;"
-           data-ad-client="ca-pub-1352515212336214"
-           data-ad-slot="1769072799"
-           data-ad-format="auto">
-      </ins>
-      <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
+      <script type="text/javascript" src="http://srvpub.com/adServe/banners?tid=29738_42511_0&size=728x90" ></script>
     </div>
   </div>
 </div>

--- a/_includes/leaderboard-ad.html
+++ b/_includes/leaderboard-ad.html
@@ -1,8 +1,13 @@
 <div class="row">
-  <div class="ads-border col-xs-12 col-sm-9 col-md-9">
+  <div class="ads-border hidden-xs col-sm-9 col-md-9">
     <div class="center-in-div">
       <!-- Top ad -->
       <script type="text/javascript" src="http://srvpub.com/adServe/banners?tid=29738_42511_0&size=728x90" ></script>
+    </div>
+  </div>
+  <div class="ads-border visible-xs">
+    <div class="center-in-div">
+      <script type="text/javascript" src="http://srvpub.com/adServe/banners?tid=29738_42511_9&size=300x250" ></script>
     </div>
   </div>
 </div>

--- a/_includes/middle-post-ad.html
+++ b/_includes/middle-post-ad.html
@@ -1,14 +1,7 @@
 <div class="row">
   <div class="col-xs-12 col-sm-12 col-md-12">
     <div class="center-in-div">
-      <ins class="adsbygoogle"
-           style="display:block"
-           data-ad-client="ca-pub-1352515212336214"
-           data-ad-slot="4941035192"
-           data-ad-format="rectangle">
-      </ins>
-      <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
+      <script type="text/javascript" src="http://srvpub.com/adServe/banners?tid=29738_42511_5&size=300x250" ></script>
     </div>
   </div>
 </div>
-

--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -13,7 +13,6 @@
         <meta name="description" content="{{ page.description }}">
       {% endif %}
       {% stylesheet styles %}
-      <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
   </head>
   <body>
     {% include google-tags.html %}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -94,21 +94,7 @@ layout: default
           {% endunless %}
         {% endif %}
       {% endfor %}
-      <div class="row">
-        <div class="col-xs-12 col-sm-12 col-md-12">
-          <div class="center-in-div">
-            <!-- Bottom ad -->
-            <ins class="adsbygoogle"
-                 style="display:block"
-                 data-ad-client="ca-pub-1352515212336214"
-                 data-ad-slot="4522232795"
-                 data-ad-format="rectangle">
-            </ins>
-            <script async src="//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js"></script>
-            <script>(adsbygoogle = window.adsbygoogle || []).push({});</script>
-          </div>
-        </div>
-      </div>
+      {% include bottom-post-ad.html %}
       <hr>
       <div class="detalles-tutorial row">
         <div class="col-xs-6 col-sm-6 col-md-6">


### PR DESCRIPTION
Se habló con el proveedor y quitaron el muy desagradable comportamiento del pop-up.

Adicionalmente se arregló el ad de leaderboard que rompía la visualización en smartphones.

Todo se ve y comporta como con AdSense
